### PR TITLE
Updates to package setup

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -11,19 +11,19 @@ permissions:
   contents: read
 
 jobs:
-
   ci_cron_tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     if: github.repository == 'spacetelescope/pypolyclip'
-    matrix:
-      include:
-        # NOTE: we don't have devdeps here
-        - name: Python 3.11
-          os: ubuntu-latest
-          python: 3.11
-          toxenv: py311-test
-          toxposargs: --run-slow
+    strategy:
+      matrix:
+        include:
+          # NOTE: we don't have devdeps here
+          - name: Python 3.11
+            os: ubuntu-latest
+            python: 3.11
+            toxenv: py311-test
+            toxposargs: --run-slow
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,7 +1,7 @@
+Original polyclip C code
+------------------------
 
-BSD 3-Clause License
-
-Original polyclip C code Copyright 2001-2007 JD Smith
+Copyright (c) 2001-2007, JD Smith
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -14,32 +14,17 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+Python wrapper code
+-------------------
 
 Copyright (C) 2010 Association of Universities for Research in Astronomy (AURA)
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-    3. The name of AURA and its representatives may not be used to
-      endorse or promote products derived from this software without
-      specific prior written permission.
+3. The name of AURA and its representatives may not be used to endorse or promote products derived from this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
+THIS SOFTWARE IS PROVIDED BY AURA "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include CHANGES.rst
-include LICENSE
+include LICENSE.rst
 include pyproject.toml
 
 prune build

--- a/README.md
+++ b/README.md
@@ -1,23 +1,45 @@
 # pypolyclip
 
-A python driver for [polyclip](http://tir.astro.utoledo.edu/jdsmith/code/idl.php) written in C by JD Smith.
+A python driver for
+[polyclip](http://tir.astro.utoledo.edu/jdsmith/code/idl.php) written in
+C by J.D. Smith.
+
+The polyclip functions were originally developed for the CUBISM
+project [Smith et al. 2007 (PASP 119, 1133)](https://ui.adsabs.harvard.edu/abs/2007PASP..119.1133S/).
+
 
 ## Installation
+
+The package can be installed using pip from the command line:
 ```
-linux> pip install .
+pip install pypolyclip
 ```
 
 ## Description
-The [polyclip](http://tir.astro.utoledo.edu/jdsmith/code/idl.php) code employs the 
-[Sutherland-Hodgman algorithm](https://en.wikipedia.org/wiki/Sutherland–Hodgman_algorithm)
-to clip simple polygons against a tessalated grid of square pixels.  Therefore, this differs from similar packages, which often clip between two arbitrary polygons.  The testing function `test/test_pypolyclip.py` can be envoked to produce the following example figures:
+The [polyclip](http://tir.astro.utoledo.edu/jdsmith/code/idl.php)
+code employs the [Sutherland-Hodgman
+algorithm](https://en.wikipedia.org/wiki/Sutherland–Hodgman_algorithm)
+to clip simple polygons against a tessalated grid of square pixels.
+Therefore, this differs from similar packages, which often clip between
+two arbitrary polygons. The testing function `test/test_pypolyclip.py`
+can be invoked to produce the following example figures:
+
 <img src="docs/_static/polygons.png"  width="350" height="350">
 <img src="docs/_static/quadrilaterals.png"  width="350" height="350">
 
-The first figure shows clipping of polygons with differing numbers of vertices.  Programmatically, this requires explicit for-loops in Python, but if the number of vertices is the same for all polygons (such as the second figure), the `numpy` can be used to improve performance by several percent.  In each figure, the Cartesian coordinates for each pixel that overlaps with a given polygon are labeled with the area of that pixel that is covered (recalling the area of a pixel is defined as 1).  Therefore, the sum of the areas of the individual pixels for each polygon should be the area of the polygon.
+The first figure shows clipping of polygons with differing numbers of
+vertices. Programmatically, this requires explicit for-loops in Python,
+but if the number of vertices is the same for all polygons (such as
+the second figure), the `numpy` can be used to improve performance by
+several percent. In each figure, the Cartesian coordinates for each
+pixel that overlaps with a given polygon are labeled with the area of
+that pixel that is covered (recalling the area of a pixel is defined as
+1). Therefore, the sum of the areas of the individual pixels for each
+polygon should be the area of the polygon.
 
 ## Example usage
-This first example demonstates polygons with the same number of vertices:
+This first example demonstrates polygons with the same number of
+vertices:
 
 ```
 # import relevant modules
@@ -42,17 +64,19 @@ py = np.array([[1.4, 1.9, 1.9, 1.4],
 # call the clipper
 xc, yc, area, slices = pypolyclip.multi(px, py, naxis)
 
-# xc,yc are the coordinates in the grid
+# xc, yc are the coordinates in the grid
 # area is the relative pixel area in that grid cell
 # slices is a list of slice objects to link between the polygons and clipped pixel grid
 
 # use these things like
 for i, s in enumerate(slices):
-	print(f'total area for polygon {i}={np.sum(area[s])}')
+    print(f'total area for polygon {i}={np.sum(area[s])}')
 
 ```
 
-This second example demonstates polygons with the different number of vertices (notice the difference is in the datatype of the `px` and `py` variables):
+This second example demonstrates polygons with the different number of
+vertices (notice the difference is in the datatype of the `px` and `py`
+variables):
 
 ```
 # import relevant modules
@@ -77,25 +101,13 @@ py = [[1.4, 1.9, 1.9, 1.65, 1.4],
 # call the clipper
 xc, yc, area, slices = pypolyclip.multi(px, py, naxis)
 
-# xc,yc are the coordinates in the grid
+# xc, yc are the coordinates in the grid
 # area is the relative pixel area in that grid cell
 # slices is a list of slice objects to link between the polygons and clipped pixel grid
 
 # use these things like
 for i, s in enumerate(slices):
-	print(f'total area for polygon {i}={np.sum(area[s])}')
-
+    print(f'total area for polygon {i}={np.sum(area[s])}')
 ```
 
-
-
-But see also the `test/test_pypolyclip.py` for examples.
-
-
-
-
-
-
-
-
-
+See also `test/test_pypolyclip.py` for examples.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,24 @@
 [metadata]
 name = pypolyclip
-author = Russell Ryan and JD Smith
+author = Russell Ryan and J.D. Smith
 author_email = rryan@stsci.edu
 license = BSD-3-Clause
-license_file = LICENSE
+license_files = LICENSE.rst
+url = https://github.com/spacetelescope/pypolyclip
+github_project = spacetelescope/pypolyclip
+edit_on_github = False
 description = A python driver to the polyclip functions
-long_description = The polyclip functions were originally developed by JD Smith for the CUBISM project (Smith et al. 2007, PASP, 119, 1133 -- https://ui.adsabs.harvard.edu/abs/2007PASP..119.1133S/)
+long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = computational geometry, polygon clipping, polygon intersection, pixelated images, CUBISM, polyclip
 classifiers =
-  Intended Audience :: Science/Research
-  Topic :: Scientific/Engineering :: Astronomy
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: Astronomy
 
 [options]
 zip_safe = False
@@ -23,8 +31,16 @@ install_requires =
 test =
     pytest
     pytest-astropy
-    pytest-tornasync
     matplotlib
 
 [flake8]
 max-line-length = 100
+
+[coverage:run]
+omit =
+    pypolyclip/tests/*
+    pypolyclip/*/tests/*
+    pypolyclip/version*
+    */pypolyclip/tests/*
+    */pypolyclip/*/tests/*
+    */pypolyclip/version*

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,14 @@
-from glob import glob
-import numpy as np
 import os
-from setuptools import setup,Extension
+from glob import glob
+
+import numpy as np
+from setuptools import Extension, setup
 
 
-def main():
-    path=('pypolyclip',)
+path = ('pypolyclip',)
+ext = Extension('.'.join(path) + '.polyclip',
+                glob(os.path.join(*path, 'src', '*.c')),
+                include_dirs=[os.path.join(*path, 'include'),
+                              np.get_include()])
 
-    
-    ext=Extension('.'.join(path)+'.polyclip',
-                  glob(os.path.join(*path,'src','*.c')),
-                  include_dirs=[os.path.join(*path,'include'),
-                                np.get_include()])
-    
-    setup(ext_modules=[ext])
-
-
-if __name__=='__main__':
-    main()
+setup(ext_modules=[ext])


### PR DESCRIPTION
This PR updates the package setup:

- Updates formatting in README and fixes install command (to be used when released on PyPI)
- Updates setup.cfg to use the README as the long description
- Adds various package metadata in setup.cfg
- Adds classifiers
- Excludes running coverage on test files
- Removes unneeded pytest-tornasync test dep
- Reformats setup.py
- Reformats the license
- Fixes the GitHub Actions cron workflow, which is currently failing