### PR TITLE
Remove old license from C source file

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,7 +1,7 @@
-Original polyclip C code
-------------------------
+Original polyclip C code (BSD 3-clause license)
+-----------------------------------------------
 
-Copyright (c) 2001-2007, JD Smith
+Copyright (c) 2001-2007, J.D. Smith
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -14,8 +14,8 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-Python wrapper code
--------------------
+Python wrapper code (BSD 3-clause license)
+------------------------------------------
 
 Copyright (C) 2010 Association of Universities for Research in Astronomy (AURA)
 

--- a/pypolyclip/src/polyclip.c
+++ b/pypolyclip/src/polyclip.c
@@ -140,26 +140,6 @@ EXAMPLE:
 		    areas, $            ; OUT: output areas
 		    px_out,py_out,ri_out) x_out
 
-#############################################################################
- LICENSE
-
-  Copyright (C) 2001,2002,2003,2006, 2007 J.D. Smith
-
-  This file is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published
-  by the Free Software Foundation; either version 2, or (at your
-  option) any later version.
-
-  This file is distributed in the hope that it will be useful, but
-  WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this file; see the file COPYING.  If not, write to the
-  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-  Boston, MA 02110-1301, USA.
-#############################################################################*/
 /*    $Id$*/
 
 #include <stdlib.h>


### PR DESCRIPTION
JD Smith agreed to license the C code as 3-clause BSD, which is reflected in the [LICENSE.rst](https://github.com/spacetelescope/pypolyclip/blob/main/LICENSE.rst) file.