### PR TITLE
TST: Use Python 3.12 stable

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -42,7 +42,7 @@ jobs:
             prefix: '(Allowed failure)'
 
           - os: ubuntu-latest
-            python: '3.12-dev'
+            python: '3.12'
             tox_env: 'py312-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true


### PR DESCRIPTION
Python 3.12 is released.