### PR TITLE
update hooks for output pixels in single method

### DIFF
--- a/pypolyclip/pypolyclip.py
+++ b/pypolyclip/pypolyclip.py
@@ -114,9 +114,9 @@ def multi(x, y, nxy):
     return xx, yy, areas, slices
 
 
-def single(x, y, nxy, return_coordinates=False):
+def single(x, y, nxy, return_polygons=False):
     """
-    Function to call the multi-polygon clipping of JD Smith
+    Function to call the single-polygon clipping of JD Smith
 
     Parameters
     ----------
@@ -128,6 +128,11 @@ def single(x, y, nxy, return_coordinates=False):
 
     nxy : list, tuple, or `np.ndarray`
         The size of the pixel grid.
+
+    return_polygons : bool, optional
+        If `True`, then will return the ``px`` and ``py`` variables
+        that describe the coordinates of the clipped polygons.
+        Default = False
 
     Returns
     -------
@@ -144,6 +149,16 @@ def single(x, y, nxy, return_coordinates=False):
         a slice object that will map between the input and output
         coordinates. This is *ONLY* returned for consistency between
         the companion function `multi()`.
+
+    px : list
+        The x-pixel coordinates of the clipped polygons. Each element of
+        the list contains a `np.array` of dtype=float that represents
+        the polygon vertices. Only returned if return_polygons=True.
+
+    py : list
+        The y-pixel coordinates of the clipped polygons. Each element of
+        the list contains a `np.array` of dtype=float that represents
+        the polygon vertices. Only returned if return_polygons=True.
 
     Notes
     -----
@@ -195,13 +210,14 @@ def single(x, y, nxy, return_coordinates=False):
     # the output for the multi function
     slices = [slice(0, len(xx), 1)]
 
-    if return_coordinates:
+    if return_polygons:
         px = []
         py = []
         pmax = ri_out[nclip]
         pind = ri_out[:pmax]
-        for i in range(len(pind)-1):
-            s = slice(pind[i], pind[i+1], 1)
+        for i in range(len(pind) - 1):
+            s = slice(pind[i], pind[i + 1], 1)
+
             px.append(px_out[s])
             py.append(py_out[s])
 

--- a/pypolyclip/pypolyclip.py
+++ b/pypolyclip/pypolyclip.py
@@ -114,7 +114,7 @@ def multi(x, y, nxy):
     return xx, yy, areas, slices
 
 
-def single(x, y, nxy):
+def single(x, y, nxy, return_coordinates=False):
     """
     Function to call the multi-polygon clipping of JD Smith
 
@@ -127,7 +127,7 @@ def single(x, y, nxy):
         The y coordinates of the polygon corners
 
     nxy : list, tuple, or `np.ndarray`
-           The size of the pixel grid.
+        The size of the pixel grid.
 
     Returns
     -------
@@ -174,7 +174,7 @@ def single(x, y, nxy):
     inds = np.empty((npix, 2), dtype=INT)
     ri_out = np.empty(npix + 1, dtype=INT)
 
-    # call the pologyon clipper
+    # call the polygon clipper
     polyclip.single(l, r, b, t,
                     np.asarray(x, dtype=FLT),
                     np.asarray(y, dtype=FLT),
@@ -195,4 +195,16 @@ def single(x, y, nxy):
     # the output for the multi function
     slices = [slice(0, len(xx), 1)]
 
-    return xx, yy, areas, slices
+    if return_coordinates:
+        px = []
+        py = []
+        pmax = ri_out[nclip]
+        pind = ri_out[:pmax]
+        for i in range(len(pind)-1):
+            s = slice(pind[i], pind[i+1], 1)
+            px.append(px_out[s])
+            py.append(py_out[s])
+
+        return xx, yy, areas, slices, px, py
+    else:
+        return xx, yy, areas, slices

--- a/pypolyclip/tests/test_pypolyclip.py
+++ b/pypolyclip/tests/test_pypolyclip.py
@@ -241,6 +241,36 @@ def test_single(plot=False):
         _plot(px[np.newaxis, ...], py[np.newaxis, ...], xc, yc, area, slices)
 
 
+def test_single_outpolygons():
+    """A module to test clipping a single polygon with output polygons."""
+
+    # define the size of the pixel grid
+    naxis = np.array((100, 100), dtype=int)
+
+    # input polygon
+    px = np.array([4.97274847, 4.54881306, 5.22725153, 5.65118694, 4.97274847])
+    py = np.array([3.64881306, 4.32725153, 4.75118694, 4.07274847, 3.64881306])
+
+    # expected output polygons' indices
+    xe = [np.array([4.9727483, 4.753302, 5., 5., 4.9727483]),
+          np.array([4.753302, 4.548813, 5., 5.]),
+          np.array([5.534765, 5., 5.]),
+          np.array([5., 5.2272515, 5.651187, 5.534765, 5.])]
+
+    ye = [np.array([3.648813, 4., 4., 3.6658418, 3.648813]),
+          np.array([4., 4.3272514, 4.6091843, 4.]),
+          np.array([4., 3.6658418, 4.]),
+          np.array([4.6091843, 4.751187, 4.0727487, 4., 4.])]
+
+    # call the clipping, but return the out indices
+    _, _, _, _, xout, yout = pypolyclip.single(px, py, naxis,
+                                               return_polygons=True)
+
+    # require equality between expected and outputs
+    assert all(np.allclose(x1, x2) for x1, x2 in zip(xout, xe))
+    assert all(np.allclose(y1, y2) for y1, y2 in zip(yout, ye))
+
+
 def _area(px, py, axis=None):
     """
     Implement the shoelace formula for area of a simple polygon


### PR DESCRIPTION
This adds the hooks to the "single" method to return the output pixel coordinates.  This output only applies to "single", as "multi" does not have any analogous feature.