### PR TITLE
Rename public-facing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,32 +18,36 @@ pip install pypolyclip
 The [polyclip](http://tir.astro.utoledo.edu/jdsmith/code/idl.php)
 code employs the [Sutherland-Hodgman
 algorithm](https://en.wikipedia.org/wiki/Sutherland–Hodgman_algorithm)
-to clip simple polygons against a tessalated grid of square pixels.
+to clip simple polygons against a tessellated grid of square pixels.
 Therefore, this differs from similar packages, which often clip between
-two arbitrary polygons. The testing function `test/test_pypolyclip.py`
-can be invoked to produce the following example figures:
+two arbitrary polygons.
+
+The testing function `test/test_pypolyclip.py` can be invoked to produce
+the following example figures:
 
 <img src="docs/_static/polygons.png"  width="350" height="350">
 <img src="docs/_static/quadrilaterals.png"  width="350" height="350">
 
+In each figure, the Cartesian coordinates for each pixel that overlaps
+with a given polygon are labeled with the area of that pixel that is
+covered (the area of a pixel is defined as 1). Therefore, the sum of the
+areas of the individual pixels for each polygon should be the total area
+of the polygon.
+
 The first figure shows clipping of polygons with differing numbers of
-vertices. Programmatically, this requires explicit for-loops in Python,
-but if the number of vertices is the same for all polygons (such as
-the second figure), the `numpy` can be used to improve performance by
-several percent. In each figure, the Cartesian coordinates for each
-pixel that overlaps with a given polygon are labeled with the area of
-that pixel that is covered (recalling the area of a pixel is defined as
-1). Therefore, the sum of the areas of the individual pixels for each
-polygon should be the area of the polygon.
+vertices, which internally requires the use of "for loops". However, if
+the number of vertices is the same for all polygons (such as the second
+figure), then [NumPy](https://numpy.org/) is used internally to improve
+performance by several percent.
+
 
 ## Example usage
 This first example demonstrates polygons with the same number of
 vertices:
 
 ```
-# import relevant modules
-import pypolyclip
 import numpy as np
+from pypolyclip import clip_multi
 
 # define the size of the pixel grid
 naxis = (100, 100)
@@ -53,34 +57,33 @@ naxis = (100, 100)
 # the x-vertices of the polygon
 px = np.array([[3.4, 3.4, 4.4, 4.4],
                [3.5, 3.5, 4.3, 4.3],
-               [3.1, 3.1, 3.9, 3.9]], dtype=float)
+               [3.1, 3.1, 3.9, 3.9]])
 
 # the y-vertices of the polygon
 py = np.array([[1.4, 1.9, 1.9, 1.4],
                [3.7, 4.4, 4.4, 3.7],
-               [2.1, 2.9, 2.9, 2.1]], dtype=float)
+               [2.1, 2.9, 2.9, 2.1]])
 
 # call the clipper
-xc, yc, area, slices = pypolyclip.multi(px, py, naxis)
+xc, yc, area, slices = clip_multi(px, py, naxis)
 
-# xc, yc are the coordinates in the grid
-# area is the relative pixel area in that grid cell
-# slices is a list of slice objects to link between the polygons and clipped pixel grid
+# xc, yc are the grid indices with overlapping pixels.
+# area is the overlapping area on a given pixel.
+# slices is a list of slice objects to link between the input polygons
+# and the clipped pixel grid.
 
-# use these things like
+# the slices object can be used to get the area of each polygon
 for i, s in enumerate(slices):
     print(f'total area for polygon {i}={np.sum(area[s])}')
-
 ```
 
-This second example demonstrates polygons with the different number of
-vertices (notice the difference is in the datatype of the `px` and `py`
-variables):
+This second example demonstrates clipping polygons that have a different
+number of vertices.  Note that `px` and `py` are lists of lists instead
+of NumPy arrays as in the first example.
 
 ```
-# import relevant modules
-import pypolyclip
 import numpy as np
+from pypolyclip import clip_multi
 
 # define the size of the pixel grid
 naxis = (100, 100)
@@ -98,13 +101,14 @@ py = [[1.4, 1.9, 1.9, 1.65, 1.4],
       [2.1, 2.1, 3.4]]
 
 # call the clipper
-xc, yc, area, slices = pypolyclip.multi(px, py, naxis)
+xc, yc, area, slices = clip_multi(px, py, naxis)
 
-# xc, yc are the coordinates in the grid
-# area is the relative pixel area in that grid cell
-# slices is a list of slice objects to link between the polygons and clipped pixel grid
+# xc, yc are the grid indices with overlapping pixels.
+# area is the overlapping area on a given pixel.
+# slices is a list of slice objects to link between the input polygons
+# and the clipped pixel grid.
 
-# use these things like
+# the slices object can be used to get the area of each polygon
 for i, s in enumerate(slices):
     print(f'total area for polygon {i}={np.sum(area[s])}')
 ```

--- a/pypolyclip/__init__.py
+++ b/pypolyclip/__init__.py
@@ -3,4 +3,4 @@ try:
 except ImportError:
     __version__ = ''
 
-from .pypolyclip import multi, single  # noqa: F401
+from .pypolyclip import clip_single, clip_multi  # noqa: F401

--- a/pypolyclip/pypolyclip.py
+++ b/pypolyclip/pypolyclip.py
@@ -7,7 +7,7 @@ INT = np.int32
 FLT = np.float32
 
 
-def multi(x, y, nxy):
+def clip_multi(x, y, nxy):
     """
     Function to call the multi-polygon clipping of JD Smith
 
@@ -114,7 +114,7 @@ def multi(x, y, nxy):
     return xx, yy, areas, slices
 
 
-def single(x, y, nxy, return_polygons=False):
+def clip_single(x, y, nxy, return_polygons=False):
     """
     Function to call the single-polygon clipping of JD Smith
 

--- a/pypolyclip/tests/test_pypolyclip.py
+++ b/pypolyclip/tests/test_pypolyclip.py
@@ -2,10 +2,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Polygon
 
-import pypolyclip
+from pypolyclip import clip_single, clip_multi
 
 
-def test_multi_numpy(plot=False):
+def test_clip_multi_numpy(plot=False):
     """A module to test clipping multiple polygons in a single pass."""
 
     # define the size of the pixel grid
@@ -43,7 +43,7 @@ def test_multi_numpy(plot=False):
     # xc,yc are the coordinates in the grid
     # area is the relative pixel area in that grid cell
     # slices is a list of slice objects to apply to the xc,yc,area arrays
-    xc, yc, area, slices = pypolyclip.multi(px, py, naxis)
+    xc, yc, area, slices = clip_multi(px, py, naxis)
 
     # compute the total area by summing over all the pixels for each polygon
     A0 = np.asarray([np.sum(area[s]) for s in slices], dtype=float)
@@ -84,7 +84,7 @@ def test_multi_numpy(plot=False):
         _plot(px, py, xc, yc, area, slices, filename="quadrilaterals.png")
 
 
-def test_multi_list(plot=False):
+def test_clip_multi_list(plot=False):
     """A module to test clipping multiple polygons in a single pass."""
 
     # define the size of the pixel grid
@@ -126,7 +126,7 @@ def test_multi_list(plot=False):
     A.append(_area(xx, yy))
 
     # clip against the pixel grid
-    xc, yc, area, slices = pypolyclip.multi(px, py, naxis)
+    xc, yc, area, slices = clip_multi(px, py, naxis)
 
     # compute the total area by summing over all the pixels for each polygon
     A0 = np.asarray([np.sum(area[s]) for s in slices], dtype=float)
@@ -164,7 +164,7 @@ def test_multi_list(plot=False):
         _plot(px, py, xc, yc, area, slices, filename="polygons.png")
 
 
-def test_single(plot=False):
+def test_clip_single(plot=False):
     """A module to test clipping a single polygon."""
 
     # define the size of the pixel grid
@@ -180,7 +180,7 @@ def test_single(plot=False):
                    2.5, 1.0, 1.0, 2.5, 3.5, 2.0, 1.0, 1.0, 2.5, 4.0, 4.0])
 
     # call the clipping
-    xc, yc, area, slices = pypolyclip.single(px, py, naxis)
+    xc, yc, area, slices = clip_single(px, py, naxis)
 
     # these are the expected values
     xc0 = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -241,7 +241,7 @@ def test_single(plot=False):
         _plot(px[np.newaxis, ...], py[np.newaxis, ...], xc, yc, area, slices)
 
 
-def test_single_outpolygons():
+def test_clip_single_outpolygons():
     """A module to test clipping a single polygon with output polygons."""
 
     # define the size of the pixel grid
@@ -263,8 +263,7 @@ def test_single_outpolygons():
           np.array([4.6091843, 4.751187, 4.0727487, 4., 4.])]
 
     # call the clipping, but return the out indices
-    _, _, _, _, xout, yout = pypolyclip.single(px, py, naxis,
-                                               return_polygons=True)
+    _, _, _, _, xout, yout = clip_single(px, py, naxis, return_polygons=True)
 
     # require equality between expected and outputs
     assert all(np.allclose(x1, x2) for x1, x2 in zip(xout, xe))
@@ -284,7 +283,7 @@ def _area(px, py, axis=None):
        the y-positions of the vertices
 
     axis : int, optional
-       the axis over the indices to sum over.  See `np.sum()` for more info.
+       The axis to sum over.  See `np.sum()` for more info.
        Default is None.
 
     Returns
@@ -482,6 +481,6 @@ def _plot(px, py, xc, yc, areas, slices, seed=1618033988, alpha=0.2,
 
 
 if __name__ == "__main__":
-    test_multi_list(plot=True)
-    test_multi_numpy(plot=True)
-    test_single(plot=True)
+    test_clip_multi_list(plot=True)
+    test_clip_multi_numpy(plot=True)
+    test_clip_single(plot=True)


### PR DESCRIPTION
This PR renames the public-facing functions to `clip_single` and `clip_multi`.  It also updates the docstrings and parameter descriptions, including a note of how to validate polygons.

This is what the new readme file looks like: https://github.com/larrybradley/pypolyclip/tree/api#readme